### PR TITLE
fixed syntax error in vercel.json file

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,9 @@
 {
     "version": 2,
     "name": "afrobank-backend-api",
-    "functions": {
-      "server.js": {
-        "runtime": "nodejs18.x"
-      }
-    },
+    "builds": [
+      { "src": "server.js", "use": "@vercel/node@18" }
+    ],
     "routes": [
       { "src": "/(.*)", "dest": "server.js" }
     ]

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
     "version": 2,
     "name": "afrobank-backend-api",
     "builds": [
-      { "src": "server.js", "use": "@vercel/node@18" }
+      { "src": "server.js", "use": "@vercel/node" }
     ],
     "routes": [
       { "src": "/(.*)", "dest": "server.js" }

--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,12 @@
 {
     "version": 2,
     "name": "afrobank-backend-api",
-    "builds": [
-      { "src": "server.js", "use": "@vercel/node" }
-    ],
-    "routes": [
-      { "src": "/(.*)", "dest": "server.js" }
-    ],
     "functions": {
       "server.js": {
         "runtime": "nodejs18.x"
       }
-    }
+    },
+    "routes": [
+      { "src": "/(.*)", "dest": "server.js" }
+    ]
   }


### PR DESCRIPTION
fixed this error 

The `functions` property cannot be used in conjunction with the `builds` property. Please remove one of them.

preventing the backend to be deployed